### PR TITLE
Use `atob` instead of `Buffer`

### DIFF
--- a/src/utils/with-auth.ts
+++ b/src/utils/with-auth.ts
@@ -6,7 +6,7 @@ type RespondWithResponse = Promise<{ response: Response }>
 
 const getCredentialsFromAuthorizationHeader = (authorizationHeader: string | undefined | null) => {
   const encoded = (authorizationHeader || '').replace('Basic ', '')
-  const decoded = Buffer.from(encoded, 'base64').toString().split(':')
+  const decoded = atob(encoded).toString().split(':')
   return {
     username: decoded[0],
     password: decoded[1],


### PR DESCRIPTION
#### Summary

[Wrangler version 1 has been deprecated](https://blog.cloudflare.com/deprecating-wrangler-v1/). [In order to use `node` components a compatibility flag could be provided](https://developers.cloudflare.com/workers/configuration/compatibility-dates/#nodejs-compatibility-flag) in the future versions. Here we're using `Buffer` [which has to be required](https://developers.cloudflare.com/workers/runtime-apis/nodejs/buffer/).

I tried the above with both v2 and v3 but had no success. Wrangler 1 generates a source with the source of `Buffer`.

Since it seems `Buffer` is the only node component we're using I replaced it here with [the `atob` function of the DOM API](https://developer.mozilla.org/en-US/docs/Web/API/atob) as suggested [here](https://developers.cloudflare.com/workers/examples/basic-auth/).