### PR TITLE
[chore] Add pdf as media format

### DIFF
--- a/.github/workflows/yarn-test.yml
+++ b/.github/workflows/yarn-test.yml
@@ -12,7 +12,7 @@ jobs:
 
     strategy:
       matrix:
-        node-version: [16.x, 18.x]
+        node-version: [18.x, 20.x, 22.x]
 
     steps:
       - uses: actions/checkout@v2
@@ -28,7 +28,7 @@ jobs:
 
     strategy:
       matrix:
-        node-version: [16.x, 18.x]
+        node-version: [18.x, 20.x, 22.x]
 
     steps:
       - uses: actions/checkout@v2

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@dbl-works/cloudflare-router",
   "author": "dbl-works",
-  "version": "0.4.0",
+  "version": "0.4.1",
   "license": "MIT",
   "main": "dist/index.js",
   "description": "Cloudflare Router",

--- a/package.json
+++ b/package.json
@@ -24,7 +24,7 @@
     }
   },
   "devDependencies": {
-    "@cloudflare/workers-types": "^3.0.0",
+    "@cloudflare/workers-types": "^4.2.0",
     "@types/jest": "^27.0.2",
     "@types/node-fetch": "^3.0.3",
     "jest": "^27.5.1",
@@ -32,7 +32,7 @@
     "jest-fetch-mock": "^3.0.3",
     "ts-jest": "^27.0.7",
     "ts-loader": "^9.2.6",
-    "typescript": "^4.4.4",
+    "typescript": "^5.7.3",
     "release-it": "^16.2.1"
   },
   "publishConfig": {

--- a/src/utils/normalize-request.ts
+++ b/src/utils/normalize-request.ts
@@ -1,6 +1,6 @@
 import { Config } from '../config'
 
-const MEDIA_FILE_EXTENSIONS = 'css gif ico jpg js otf jpeg png svg ttf webp woff woff2 csv json'.split(' ')
+const MEDIA_FILE_EXTENSIONS = 'css gif ico jpg js otf jpeg png pdf svg ttf webp woff woff2 csv json'.split(' ')
 const hasMediaFileExtension = (path: string): boolean => {
   const ext = path.split('.').pop()?.toLowerCase()
   return ext ? MEDIA_FILE_EXTENSIONS.includes(ext) : false

--- a/test/utils/normalize-request.test.ts
+++ b/test/utils/normalize-request.test.ts
@@ -74,3 +74,9 @@ test('simple path replace', () => {
   expect(request.url).toEqual('https://example.com/new-path')
   expect(cache).toEqual(true)
 })
+
+test('maps pdf to s3 bucket location', () => {
+  const { request, cache } = normalizeRequest(new Request('https://cdn.example.com/some/file.pdf'), TEST_ROUTES)
+  expect(request.url).toEqual('https://s3.eu-central-1.amazonaws.com/bucket-name/public/some/file.pdf')
+  expect(cache).toEqual(true)
+})

--- a/test/utils/normalize-request.test.ts
+++ b/test/utils/normalize-request.test.ts
@@ -35,7 +35,7 @@ test('maps subpath js file to s3 bucket subpath', () => {
 
 test('maps js to s3 bucket root', () => {
   const { request, cache } = normalizeRequest(new Request('https://cdn.example.com/some/file.js'), TEST_ROUTES)
-  expect(request.url).toEqual('https://s3.eu-central-1.amazonaws.com/cdn.example.com/some/file.js')
+  expect(request.url).toEqual('https://s3.eu-central-1.amazonaws.com/bucket-name/public/some/file.js')
   expect(cache).toEqual(true)
 })
 

--- a/test/utils/normalize-request.test.ts
+++ b/test/utils/normalize-request.test.ts
@@ -5,7 +5,7 @@ const TEST_ROUTES = {
   'example.com/admin': 'https://s3.eu-central-1.amazonaws.com/assets.example.com/admin',
   'dashboard.example.com': 's3://eu-central-1.assets.example.com/dashboard',
   'fonts.example.com': 's3://us-east-1.fonts.example.com',
-  'cdn.example.com': 'https://s3.eu-central-1.amazonaws.com/cdn.example.com',
+  'cdn.example.com': 's3://eu-central-1.bucket-name/public',
   '/old-path': '/new-path',
 }
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -368,10 +368,10 @@
   resolved "https://registry.npmjs.org/@bcoe/v8-coverage/-/v8-coverage-0.2.3.tgz"
   integrity sha512-0hYQ8SB4Db5zvZB4axdMHGwEaQjkZzFjQiN9LVYvIFB2nSUHW9tYpxWriPrWDASIxiaXax83REcLxuSdnGPZtw==
 
-"@cloudflare/workers-types@^3.0.0":
-  version "3.19.0"
-  resolved "https://registry.yarnpkg.com/@cloudflare/workers-types/-/workers-types-3.19.0.tgz#f3791b80b23f7cf0072f2e67e98aa37801204b6c"
-  integrity sha512-0FRcsz7Ea3jT+gc5gKPIYciykm1bbAaTpygdzpCwGt0RL+V83zWnYN30NWDW4rIHj/FHtz+MIuBKS61C8l7AzQ==
+"@cloudflare/workers-types@^4.2.0":
+  version "4.20250109.0"
+  resolved "https://registry.yarnpkg.com/@cloudflare/workers-types/-/workers-types-4.20250109.0.tgz#b02e6c2c46117c619e819869a04320bc7bb2e9eb"
+  integrity sha512-Y1zgSaEOOevl9ORpzgMcm4j535p3nK2lrblHHvYM2yxR50SBKGh+wvkRFAIxWRfjUGZEU+Fp6923EGioDBbobA==
 
 "@cloudflare/workers-types@^4.20221111.1":
   version "4.20230914.0"
@@ -4923,10 +4923,10 @@ typedarray-to-buffer@^3.1.5:
   dependencies:
     is-typedarray "^1.0.0"
 
-typescript@^4.4.4:
-  version "4.9.5"
-  resolved "https://registry.yarnpkg.com/typescript/-/typescript-4.9.5.tgz#095979f9bcc0d09da324d58d03ce8f8374cbe65a"
-  integrity sha512-1FXk9E2Hm+QzZQ7z+McJiHL4NW1F2EzMu9Nq9i3zAaGqibafqYwCVU6WyWAuyQRRzOlxou8xZSyXLEN8oKj24g==
+typescript@^5.7.3:
+  version "5.7.3"
+  resolved "https://registry.yarnpkg.com/typescript/-/typescript-5.7.3.tgz#919b44a7dbb8583a9b856d162be24a54bf80073e"
+  integrity sha512-84MVSjMEHP+FQRPy3pX9sTVV/INIex71s9TL2Gm5FG/WG1SqXeKyZ0k7/blY/4FdOzI12CBy1vGc4og/eus0fw==
 
 unbox-primitive@^1.0.2:
   version "1.0.2"


### PR DESCRIPTION
1. Add pdf as media format, since with current setup router returns `/index.html` paths for `.pdf` requests (see spec)
2. bonus: Bump packages

<img width="932" alt="Screenshot 2025-01-16 at 14 35 34" src="https://github.com/user-attachments/assets/59cce7c0-ed00-40a4-9c64-122d071dccdc" />
